### PR TITLE
Support Blink Mini 2, Fix broken doorbell integration

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "Websocket Server (DEV)",
       "type": "shell",
-      "command": "go run cmd/server/main.go --address=:8080 --env=development",
+      "command": "go run main.go server --address=:8080 --env=development --origins=*",
       "problemMatcher": []
     }
   ]

--- a/common/util.go
+++ b/common/util.go
@@ -32,6 +32,7 @@ func GetLiveviewPath(deviceType string) (string, error) {
 	case "camera":
 		return "%s/api/v5/accounts/%d/networks/%d/cameras/%d/liveview", nil
 	case "owl":
+	case "hawk":
 		return "%s/api/v2/accounts/%d/networks/%d/owls/%d/liveview", nil
 	case "doorbell":
 	case "lotus":

--- a/common/util.go
+++ b/common/util.go
@@ -31,11 +31,9 @@ func GetLiveviewPath(deviceType string) (string, error) {
 	switch deviceType {
 	case "camera":
 		return "%s/api/v5/accounts/%d/networks/%d/cameras/%d/liveview", nil
-	case "owl":
-	case "hawk":
+	case "owl", "hawk":
 		return "%s/api/v2/accounts/%d/networks/%d/owls/%d/liveview", nil
-	case "doorbell":
-	case "lotus":
+	case "doorbell", "lotus":
 		return "%s/api/v2/accounts/%d/networks/%d/doorbells/%d/liveview", nil
 	}
 

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -34,11 +34,18 @@ func TestGetLiveviewPathOwl(t *testing.T) {
 	assert.Equal(t, err, nil)
 }
 
+func TestGetLiveviewPathHawk(t *testing.T) {
+	path, err := common.GetLiveviewPath("hawk")
+
+	assert.Equal(t, "%s/api/v2/accounts/%d/networks/%d/owls/%d/liveview", path)
+	assert.Equal(t, err, nil)
+}
+
 func TestGetLiveviewPathDoorbell(t *testing.T) {
 	path, err := common.GetLiveviewPath("doorbell")
 
-	assert.Equal(t, "", path)
-	assert.NotEqual(t, err, nil)
+	assert.Equal(t, "%s/api/v2/accounts/%d/networks/%d/doorbells/%d/liveview", path)
+	assert.Equal(t, err, nil)
 }
 
 func TestGetLiveviewPathLotus(t *testing.T) {


### PR DESCRIPTION
- Update the mapping to include Mini 2 (hawk) livestream URL
- Fix broken multi-case doorbell/lotus livestream URL mapping